### PR TITLE
agent-client: harden HTTP-tool URL allow-list against prefix bypass

### DIFF
--- a/supabase/functions/agent-client/tools/http.ts
+++ b/supabase/functions/agent-client/tools/http.ts
@@ -68,6 +68,53 @@ export const RequestToolOutputSchema = z.union([
   }),
 ]);
 
+/**
+ * Strict URL allow-list check.
+ *
+ * Returns `true` only when `inputUrl` resolves to a URL whose host matches
+ * `configUrl`'s host exactly, whose scheme is http(s), whose userinfo is
+ * empty, and whose path either matches `configUrl`'s path exactly (no
+ * wildcard) or extends it on a `/` path-boundary (wildcard `configUrl`
+ * ends in `/*`).
+ *
+ * Replaces a previous `startsWith(baseUrl)` check that allowed:
+ *   - host-suffix confusion (`api.acme.com.evil.com`)
+ *   - userinfo trick        (`api.acme.com@evil.com`)
+ *   - path-boundary escape  (`/public/*` matched `/public-admin/...`)
+ */
+function isUrlAllowed(configUrl: string, inputUrl: string): boolean {
+  const isWildcard = configUrl.endsWith("/*");
+  let cfg: URL;
+  let inp: URL;
+  try {
+    cfg = new URL(isWildcard ? configUrl.slice(0, -2) : configUrl);
+    inp = new URL(inputUrl);
+  } catch {
+    return false;
+  }
+
+  if (inp.protocol !== "https:" && inp.protocol !== "http:") {
+    return false;
+  }
+  if (inp.username !== "" || inp.password !== "") {
+    return false;
+  }
+  if (inp.host !== cfg.host) {
+    return false;
+  }
+
+  if (!isWildcard) {
+    return inp.pathname === cfg.pathname && inp.search === cfg.search;
+  }
+
+  // Wildcard: require exact path-prefix on a `/` boundary.
+  const base = cfg.pathname.endsWith("/") ? cfg.pathname : cfg.pathname + "/";
+  return (
+    inp.pathname === cfg.pathname.replace(/\/$/, "") ||
+    inp.pathname.startsWith(base)
+  );
+}
+
 export async function requestToolImplementation(
   input: z.infer<typeof RequestToolInputSchema>,
   config: LocalHTTPToolConfig["config"],
@@ -77,23 +124,12 @@ export async function requestToolImplementation(
 
   // Security check: URL restriction
   if (config.url) {
-    if (config.url.endsWith("/*")) {
-      const baseUrl = config.url.slice(0, -2);
-      if (!input.url.startsWith(baseUrl)) {
-        return {
-          status: 403,
-          isError: true,
-          message: `URL not allowed. Must start with ${baseUrl}`,
-        };
-      }
-    } else {
-      if (input.url !== config.url) {
-        return {
-          status: 403,
-          isError: true,
-          message: `URL not allowed. Must match ${config.url}`,
-        };
-      }
+    if (!isUrlAllowed(config.url, input.url)) {
+      return {
+        status: 403,
+        isError: true,
+        message: `URL not allowed by tool config (${config.url}).`,
+      };
     }
   }
 


### PR DESCRIPTION
Hardens the URL allow-list check in `supabase/functions/agent-client/tools/http.ts`.

The current check on `config.url` ending in `/*` uses a plain `String.prototype.startsWith` on the raw input URL. Because the comparison is a pure string match (not a parsed URL match), it accepts several inputs that resolve to a different effective host or escape the intended path prefix. The merge order in the request below means `config.headers` (the operator-provisioned secret, typically a Bearer token) is sent on every request that passes the check, so a bypass leaks credentials to a host the operator did not allow:

```ts
headers: {
  ...contextHeaders(context),
  ...input.headers,
  ...config.headers,
},
```

This matters here because `input.url` ultimately originates from LLM output that is driven by external WhatsApp / Instagram messages — i.e. untrusted text.

**Change:** replace the inline `startsWith` check with a small `isUrlAllowed()` helper that parses both URLs with WHATWG `URL` and enforces:

- exact host match (including port),
- empty userinfo (no `user@host` rewrites),
- `http(s)` scheme,
- `/`-delimited path-boundary for wildcard prefixes,
- exact path + query match when no wildcard.

No behaviour change for legitimate calls; only previously-accepted-but-unsafe inputs are now rejected with the existing 403 path.

### Verification

Ten test cases run against the new helper (3 legitimate ALLOW + 7 prior bypass classes DENY) — all pass. The reproducer set + full write-up I'll share privately with you, happy to send it on the email thread.

### A few other small things I noticed while reading

I didn't include them in this PR to keep it focused, but flagging so you have the list. I'm happy to send follow-up PRs for any/all, or you can fix yourself — whichever you prefer:

- `_shared/media.ts` uses `uri.replace(BASE_URI, "")` (substring strip, not a parser) — latent path-traversal hazard.
- `whatsapp-webhook/index.ts` and `instagram-webhook/index.ts` log the *expected* HMAC alongside the received one on mismatch, which is a signing oracle for anyone who can read logs.
- Both webhooks return `200 OK` silently when `APP_ID` / `APP_SECRET` are unset, which is fail-open ingestion.
- `mcp/tools.ts` `searchContacts` doesn't escape `LIKE` patterns and uses an unbounded `limit * 20`.

### Suggested follow-up (optional)

For future drive-by reports, enabling [GitHub Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) on this repo gives reporters a clear private channel — happy to send a tiny PR adding a `SECURITY.md` pointing at it too if useful.